### PR TITLE
Puerto Rico Statehood Decision Change

### DIFF
--- a/CWEFanFork/decisions/US decisions.txt
+++ b/CWEFanFork/decisions/US decisions.txt
@@ -161,7 +161,7 @@ political_decisions = { #Consider Revising
 		allow = {
 			war = no
 			election = no
-			OR = { ruling_party_ideology = populist ruling_party_ideology = nationalist ruling_party_ideology = communist ruling_party_ideology = communist_social }
+			OR = { ruling_party_ideology = populist ruling_party_ideology = nationalist ruling_party_ideology = communist ruling_party_ideology = communist_social ruling_party_ideology = social_democrat AND = { ruling_party_ideology = liberal year = 1980 } }
 			PUR = { NOT = { OR = { ruling_party_ideology = populist ruling_party_ideology = nationalist ruling_party_ideology = communist ruling_party_ideology = communist_social } } }
 		}
 


### PR DESCRIPTION
Modified the decision for the U.S. to annex Puerto Rico. Social Democrats may annex Puerto Rico at any time. Liberals may now also annex Puerto Rico, as long as it is after 1980. This is to better represent the growth of the PR Statehood movement in mainstream circles.